### PR TITLE
Update github.sh

### DIFF
--- a/bundles/github.sh
+++ b/bundles/github.sh
@@ -8,9 +8,10 @@ echo "Press any key when your in"
 read foo
 
 echo "Clone all the things"
-git clone git@github.com:degordian/yapp-framework.git ~/work
-git clone git@github.com:degordian/yapp.git ~/work
-git clone git@github.com:degordian/iframework.git ~/work
-git clone git@github.com:degordian/iapp.git ~/work
-git clone git@github.com:degordian/dwp.git ~/work
+cd ~/work
+git clone git@github.com:degordian/yapp-framework.git 
+git clone git@github.com:degordian/yapp.git 
+git clone git@github.com:degordian/iframework.git 
+git clone git@github.com:degordian/iapp.git 
+git clone git@github.com:degordian/dwp.git
 echo "Good news, the cloning has completed!"

--- a/bundles/github.sh
+++ b/bundles/github.sh
@@ -8,6 +8,7 @@ echo "Press any key when your in"
 read foo
 
 echo "Clone all the things"
+#change working directory to work for cloning into respective folders
 cd ~/work
 git clone git@github.com:degordian/yapp-framework.git 
 git clone git@github.com:degordian/yapp.git 
@@ -15,3 +16,5 @@ git clone git@github.com:degordian/iframework.git
 git clone git@github.com:degordian/iapp.git 
 git clone git@github.com:degordian/dwp.git
 echo "Good news, the cloning has completed!"
+#revert to original directory
+cd -


### PR DESCRIPTION
`git clone git@github.com:degordian/yapp-framework.git ~/work` clones contents of "yapp-framework" repository into ~/work folder directly.

After cloning first repository, others can't be cloned because the work folder has the contents of yapp-framework and therefore is not empty and can not be overwritten.

Changing to work directory before cloning repositories ensures that the repositories are cloned in their respective folders.